### PR TITLE
Updated the script to return the original position/rotation

### DIFF
--- a/DemoScene/demo.gd
+++ b/DemoScene/demo.gd
@@ -1,7 +1,8 @@
 extends Node3D
 
 @export var node_shaker_3d : NodeShaker3D
+@export var test_cube: Node3D
 
 func _process(delta: float) -> void:
 	if Input.is_action_just_pressed("ui_accept"):
-		node_shaker_3d.induce_stress(1.0)
+		node_shaker_3d.induce_stress(1.0, test_cube)

--- a/DemoScene/demo.tscn
+++ b/DemoScene/demo.tscn
@@ -35,9 +35,10 @@ albedo_color = Color(0.67451, 0, 0.027451, 1)
 [sub_resource type="BoxMesh" id="BoxMesh_kcral"]
 material = SubResource("StandardMaterial3D_6mj58")
 
-[node name="Demo" type="Node3D" node_paths=PackedStringArray("node_shaker_3d")]
+[node name="Demo" type="Node3D" node_paths=PackedStringArray("node_shaker_3d", "test_cube")]
 script = ExtResource("1_fyaxq")
 node_shaker_3d = NodePath("NodeShaker3D")
+test_cube = NodePath("Cube")
 
 [node name="Environment" type="Node3D" parent="."]
 
@@ -64,9 +65,8 @@ transform = Transform3D(1, 0, 0, 0, 0.965926, 0.258819, 0, -0.258819, 0.965926, 
 transform = Transform3D(1, -6.65242e-06, 6.0559e-05, 6.653e-06, 1, -9.59318e-06, -6.05589e-05, 9.59358e-06, 1, 0.000258952, 1.00009, -1.31479e-05)
 mesh = SubResource("BoxMesh_kcral")
 
-[node name="NodeShaker3D" type="Node3D" parent="." node_paths=PackedStringArray("target")]
+[node name="NodeShaker3D" type="Node3D" parent="."]
 script = ExtResource("1_2jt11")
-target = NodePath("../Cube")
 recovery_speed = 2.0
 frequency = 25.0
 


### PR DESCRIPTION
- `induce_stress` now allows for one-liner to start shaking, instead of 2 lines (shaker.target = someNode3D)
- `shake_once` was deleted because it's obsolete.
- The demo was updated for it as well.